### PR TITLE
Added Pipeline Endpoint to DevOps pipeline

### DIFF
--- a/automation/deploy-ml-train-pipeline.yml
+++ b/automation/deploy-ml-train-pipeline.yml
@@ -91,4 +91,4 @@ steps:
     scriptLocation: inlineScript
     scriptType: bash
     inlineScript: |
-      python pipelines-python/train/publish_to_endpoint.py --pipeline_id=$(pipeline_id) --pipeline_endpoint=$(pipeline_endpoint_name)
+      python pipelines-python/train/publish_to_endpoint.py --pipeline_id=$(pipeline_id) --pipeline_endpoint_name=$(pipeline_endpoint_name)

--- a/automation/deploy-ml-train-pipeline.yml
+++ b/automation/deploy-ml-train-pipeline.yml
@@ -1,6 +1,7 @@
 # This pipeline:
-# * deploys the training ML pipeline and
-# * runs a small test training dataset through it for ensuring full functionality of the deployed ML pipeline
+# * Deploys the training ML pipeline as a published pipeline
+# * Runs a small test training dataset through it for ensuring full functionality of the deployed ML pipeline
+# * Publishes it as a new Pipeline Endpoint or adds it as default to an existing Pipeline Endpoint
 
 trigger:
 - master
@@ -13,6 +14,7 @@ variables:
   workspace: 'aml-demo'
   aml_compute_target: 'cpu-cluster'
   pipeline_name: 'training-pipeline'
+  pipeline_endpoint_name: 'training-pipeline-endpoint'
   dataset: 'german-credit-dataset'
   dataset_test: 'german-credit-ci-test' # Dataset used for testing the training pipeline
 
@@ -81,3 +83,12 @@ steps:
   displayName: 'Publish test results from pipeline test run'
   inputs:
     testRunTitle: 'Test results for published pipeline'
+
+- task: AzureCLI@2
+  displayName: 'Add pipeline to Pipeline Endpoint'
+  inputs:
+    azureSubscription: '$(azure_service_connection_name)'
+    scriptLocation: inlineScript
+    scriptType: bash
+    inlineScript: |
+      python pipelines-python/train/publish_to_endpoint.py --pipeline_id=$(pipeline_id) --pipeline_endpoint=$(pipeline_endpoint_name)

--- a/instructions/04-automation.md
+++ b/instructions/04-automation.md
@@ -38,15 +38,17 @@ This pipeline is used to the automatically deploy the Python-based ML training p
     workspace: 'aml-demo'
     aml_compute_target: 'cpu-cluster'
     pipeline_name: 'training-pipeline'
+    pipeline_endpoint_name: 'training-pipeline-endpoint'
     dataset: 'german-credit-dataset'
     dataset_test: 'german-credit-ci-test' # Dataset used for testing the training pipeline
   ```
-1. Review the YAML file, this CI/CD pipeline has four key steps:
+1. Review the YAML file, this CI/CD pipeline has five key steps:
     * Attach folder to workspace
     * Create the AML Compute target
-    * Create pipeline for model training
+    * Create and publish pipeline for model training
     * Execute tests for running the training pipeline using a small training dataset (functional test)
     * Publish the test results
+    * Add published pipeline behind a Pipeline Endpoint, so that the URL stays the same
 1. Select `Save and run` to save run the pipeline.
 
 ### `Train, register, deploy` pipeline

--- a/pipelines-python/train/publish_to_endpoint.py
+++ b/pipelines-python/train/publish_to_endpoint.py
@@ -8,7 +8,7 @@ print("Azure ML SDK version:", azureml.core.VERSION)
 
 parser = argparse.ArgumentParser("publish_to_pipeline_endpoint")
 parser.add_argument("--pipeline_id", type=str, help="Id of the published pipeline that should get added to the Pipeline Endpoint", required=True)
-parser.add_argument("--pipeline_endpoint", type=str, help="Name of the Pipeline Endpoint that the the pipeline should be added to", required=True)
+parser.add_argument("--pipeline_endpoint_name", type=str, help="Name of the Pipeline Endpoint that the the pipeline should be added to", required=True)
 args = parser.parse_args()
 print(f'Arguments: {args}')
 
@@ -23,20 +23,18 @@ print(f'Region: {ws.location}')
 print(f'Subscription id: {ws.subscription_id}')
 print(f'Resource group: {ws.resource_group}')
 
-endpoint_name = args.pipeline_endpoint
+endpoint_name = args.pipeline_endpoint_name
 pipeline_id = args.pipeline_id
 published_pipeline = PublishedPipeline.get(workspace=ws, id=pipeline_id)
 
-# Check if PipelineEndpoint already exists
-if any(pe.name == endpoint_name for pe in PipelineEndpoint.list(ws)):
-    print(f'Pipeline Endpoint with name {endpoint_name} already exists, will add pipeline {pipeline_id} to it')
-    pipeline_endpoint = PipelineEndpoint.get(workspace=ws, name=endpoint_name)
-    pipeline_endpoint.add(published_pipeline)
-    # Set it to default, as we already tested it beforehand
-    pipeline_endpoint.set_default(published_pipeline)
-else:
-    print(f'Will create new Pipeline Endpoint with name {endpoint_name} and add pipeline {pipeline_id} to it')
-    pipeline_endpoint = PipelineEndpoint.publish(workspace=ws,
-                                                name=endpoint_name,
-                                                pipeline=published_pipeline,
-                                                description="New Training Pipeline Endpoint")
+# Add tested published pipeline to pipeline endpoint
+try:
+    pl_endpoint = PipelineEndpoint.get(workspace=ws, name=endpoint_name)
+    pl_endpoint.add_default(published_pipeline)
+    print(f'Added pipeline {pipeline_id} to Pipeline Endpoint with name {endpoint_name}')
+except Exception:
+    print(f'Will create new Pipeline Endpoint with name {endpoint_name} with pipeline {pipeline_id}')
+    pl_endpoint = PipelineEndpoint.publish(workspace=ws,
+                                           name=endpoint_name,
+                                           pipeline=published_pipeline,
+                                           description="New Training Pipeline Endpoint")

--- a/pipelines-python/train/publish_to_endpoint.py
+++ b/pipelines-python/train/publish_to_endpoint.py
@@ -1,0 +1,42 @@
+import os
+import argparse
+import azureml.core
+from azureml.core import Workspace
+from azureml.pipeline.core import Pipeline, PublishedPipeline, PipelineEndpoint
+
+print("Azure ML SDK version:", azureml.core.VERSION)
+
+parser = argparse.ArgumentParser("publish_to_pipeline_endpoint")
+parser.add_argument("--pipeline_id", type=str, help="Id of the published pipeline that should get added to the Pipeline Endpoint", required=True)
+parser.add_argument("--pipeline_endpoint", type=str, help="Name of the Pipeline Endpoint that the the pipeline should be added to", required=True)
+args = parser.parse_args()
+print(f'Arguments: {args}')
+
+print('Connecting to workspace')
+ws = Workspace.from_config()
+print(f'WS name: {ws.name}\nRegion: {ws.location}\nSubscription id: {ws.subscription_id}\nResource group: {ws.resource_group}')
+
+# Connect to the workspace
+ws = Workspace.from_config()
+print(f'WS name: {ws.name}')
+print(f'Region: {ws.location}')
+print(f'Subscription id: {ws.subscription_id}')
+print(f'Resource group: {ws.resource_group}')
+
+endpoint_name = args.pipeline_endpoint
+pipeline_id = args.pipeline_id
+published_pipeline = PublishedPipeline.get(workspace=ws, id=pipeline_id)
+
+# Check if PipelineEndpoint already exists
+if any(pe.name == endpoint_name for pe in PipelineEndpoint.list(ws)):
+    print(f'Pipeline Endpoint with name {endpoint_name} already exists, will add pipeline {pipeline_id} to it')
+    pipeline_endpoint = PipelineEndpoint.get(workspace=ws, name=endpoint_name)
+    pipeline_endpoint.add(published_pipeline)
+    # Set it to default, as we already tested it beforehand
+    pipeline_endpoint.set_default(published_pipeline)
+else:
+    print(f'Will create new Pipeline Endpoint with name {endpoint_name} and add pipeline {pipeline_id} to it')
+    pipeline_endpoint = PipelineEndpoint.publish(workspace=ws,
+                                                name=endpoint_name,
+                                                pipeline=published_pipeline,
+                                                description="New Training Pipeline Endpoint")

--- a/pipelines-python/train/publish_to_endpoint.py
+++ b/pipelines-python/train/publish_to_endpoint.py
@@ -9,6 +9,7 @@ print("Azure ML SDK version:", azureml.core.VERSION)
 parser = argparse.ArgumentParser("publish_to_pipeline_endpoint")
 parser.add_argument("--pipeline_id", type=str, help="Id of the published pipeline that should get added to the Pipeline Endpoint", required=True)
 parser.add_argument("--pipeline_endpoint_name", type=str, help="Name of the Pipeline Endpoint that the the pipeline should be added to", required=True)
+parser.add_argument("--pipeline_endpoint_description", type=str, help="Description for the Pipeline Endpoint", default="Pipeline Endpoint", required=False)
 args = parser.parse_args()
 print(f'Arguments: {args}')
 
@@ -16,14 +17,8 @@ print('Connecting to workspace')
 ws = Workspace.from_config()
 print(f'WS name: {ws.name}\nRegion: {ws.location}\nSubscription id: {ws.subscription_id}\nResource group: {ws.resource_group}')
 
-# Connect to the workspace
-ws = Workspace.from_config()
-print(f'WS name: {ws.name}')
-print(f'Region: {ws.location}')
-print(f'Subscription id: {ws.subscription_id}')
-print(f'Resource group: {ws.resource_group}')
-
 endpoint_name = args.pipeline_endpoint_name
+pipeline_description = args.pipeline_endpoint_description
 pipeline_id = args.pipeline_id
 published_pipeline = PublishedPipeline.get(workspace=ws, id=pipeline_id)
 
@@ -37,4 +32,4 @@ except Exception:
     pl_endpoint = PipelineEndpoint.publish(workspace=ws,
                                            name=endpoint_name,
                                            pipeline=published_pipeline,
-                                           description="New Training Pipeline Endpoint")
+                                           description=pipeline_description)


### PR DESCRIPTION
This PR adds the capability to publish the AML Pipelines (created inside the DevOps pipeline) to a new/existing Pipeline Endpoint. Documentation has been updated too.
